### PR TITLE
fix parsing outzip in afhq data preprocessing

### DIFF
--- a/dataset_preprocessing/afhq/runme.py
+++ b/dataset_preprocessing/afhq/runme.py
@@ -19,7 +19,7 @@ import gdown
 
 parser = argparse.ArgumentParser()
 parser.add_argument('inzip', type=str) # the AFHQ zip downloaded from starganV2 (https://github.com/clovaai/stargan-v2)
-parser.add_argument('outzip', type=str, required=False, default='processed_afhq.zip') # this is the output path to write the new zip
+parser.add_argument('--outzip', type=str, required=False, default='processed_afhq.zip') # this is the output path to write the new zip
 args = parser.parse_args()
 
 


### PR DESCRIPTION
outzip is defined as a positional argument (no -- option before the name) in dataset_preprocessing/afhq/runme.py, line 22. Therefore, the use of the argument "required=False" in line 22  throws the following error:
TypeError: 'required' is an invalid argument for positionals 

This pull request replaces "outzip" with "--outzip" in dataset_preprocessing/afhq/runme.py, line 22m to fix the following issue.